### PR TITLE
feat: support arc browser sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class Companies(BaseModel):
 async def main():
     # Create configuration
     config = StagehandConfig(
-        env = "BROWSERBASE", # or LOCAL
+        env = "BROWSERBASE", # or LOCAL or ARC or ARC_PERSIST
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="google/gemini-2.5-flash-preview-05-20",

--- a/examples/agent_example.py
+++ b/examples/agent_example.py
@@ -36,7 +36,7 @@ async def main():
     # Build a unified configuration object for Stagehand
     config = StagehandConfig(
         env="BROWSERBASE",
-        # env="LOCAL",
+        # env="LOCAL" or "ARC" or "ARC_PERSIST",
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="gpt-4o",

--- a/examples/example.py
+++ b/examples/example.py
@@ -49,6 +49,7 @@ async def main():
     # Build a unified configuration object for Stagehand
     config = StagehandConfig(
         env="BROWSERBASE",
+        # env="LOCAL" or "ARC" or "ARC_PERSIST",
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         headless=False,

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -20,7 +20,7 @@ class Companies(BaseModel):
 async def main():
     # Create configuration
     config = StagehandConfig(
-        env = "BROWSERBASE", # or LOCAL
+        env = "BROWSERBASE", # or LOCAL or ARC or ARC_PERSIST
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="google/gemini-2.5-flash-preview-05-20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ python_classes = [ "Test*",]
 python_functions = [ "test_*",]
 asyncio_mode = "auto"
 addopts = [ "--cov=stagehand", "--cov-report=html:htmlcov", "--cov-report=term-missing", "--cov-report=xml", "--strict-markers", "--strict-config", "-ra", "--tb=short",]
-markers = [ "unit: Unit tests for individual components", "integration: Integration tests requiring multiple components", "e2e: End-to-end tests with full workflows", "slow: Tests that take longer to run", "browserbase: Tests requiring Browserbase connection", "local: Tests for local browser functionality", "llm: Tests involving LLM interactions", "mock: Tests using mock objects only", "performance: Performance and load tests", "smoke: Quick smoke tests for basic functionality",]
+markers = [ "unit: Unit tests for individual components", "integration: Integration tests requiring multiple components", "e2e: End-to-end tests with full workflows", "slow: Tests that take longer to run", "browserbase: Tests requiring Browserbase connection", "local: Tests for local browser functionality", "arc: Tests for Arc browser functionality", "llm: Tests involving LLM interactions", "mock: Tests using mock objects only", "performance: Performance and load tests", "smoke: Quick smoke tests for basic functionality",]
 filterwarnings = [ "ignore::DeprecationWarning", "ignore::PendingDeprecationWarning", "ignore::UserWarning:pytest_asyncio", "ignore::RuntimeWarning",]
 minversion = "7.0"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,8 @@ markers =
     integration: marks tests as integration tests
     smoke: marks tests as smoke tests
     local: marks tests as local integration tests
+    arc: marks tests as Arc browser integration tests
+    arc_persist: marks tests as Arc persistent session integration tests
     api: marks tests as API integration tests
     e2e: marks tests as end-to-end tests
     regression: marks tests as regression tests

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,11 +1,14 @@
+import asyncio
 import json
+import uuid
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
+from .arc import launch_arc_browser
 from .utils import convert_dict_keys_to_camel_case
 
-__all__ = ["_create_session", "_execute"]
+__all__ = ["_create_session", "_create_arc_session", "_attach_arc_session", "_execute"]
 
 
 async def _create_session(self):
@@ -97,6 +100,67 @@ async def _create_session(self):
         raise RuntimeError(f"Invalid response format: {resp.text}")
 
     self.session_id = data["data"]["sessionId"]
+
+
+async def _create_arc_session(self):
+    """Launch Arc browser in remote debugging mode and set up a local session.
+
+    This method starts the Arc browser using its default macOS installation path
+    and enables the remote debugging protocol. A unique session ID is generated
+    for use throughout Stagehand just like in Browserbase mode, but no external
+    server is contacted. The launched browser can then be accessed via CDP using
+    the generated debugging port.
+    """
+
+    debug_port = 9222
+
+    self.logger.info("Launching Arc browser in debug mode...")
+
+    # Start Arc with remote debugging enabled
+    self._arc_process = await launch_arc_browser(debug_port)
+
+    # Give the browser a moment to start listening on the port
+    await asyncio.sleep(2)
+
+    # Generate a session ID if one was not provided
+    if not self.session_id:
+        self.session_id = str(uuid.uuid4())
+
+    # Ensure subsequent calls connect via CDP to the launched Arc browser
+    if hasattr(self, "local_browser_launch_options"):
+        self.local_browser_launch_options.setdefault(
+            "cdp_url", f"http://localhost:{debug_port}"
+        )
+    else:
+        self.local_browser_launch_options = {
+            "cdp_url": f"http://localhost:{debug_port}"
+        }
+
+
+async def _attach_arc_session(self):
+    """Attach to an existing Arc browser session running in debug mode.
+
+    This helper assumes the Arc browser is already running with the remote
+    debugging protocol enabled (typically on port 9222). It configures Stagehand
+    to connect via CDP without launching a new browser process, allowing reuse
+    of authenticated sessions.
+    """
+
+    debug_port = 9222
+
+    self.logger.info("Attaching to existing Arc browser session...")
+
+    if not self.session_id:
+        self.session_id = str(uuid.uuid4())
+
+    if hasattr(self, "local_browser_launch_options"):
+        self.local_browser_launch_options.setdefault(
+            "cdp_url", f"http://localhost:{debug_port}"
+        )
+    else:
+        self.local_browser_launch_options = {
+            "cdp_url": f"http://localhost:{debug_port}"
+        }
 
 
 async def _execute(self, method: str, payload: dict[str, Any]) -> Any:

--- a/stagehand/arc.py
+++ b/stagehand/arc.py
@@ -1,0 +1,23 @@
+import asyncio
+from pathlib import Path
+
+
+async def launch_arc_browser(port: int = 9222) -> asyncio.subprocess.Process:
+    """Launch the Arc browser with remote debugging enabled.
+
+    Args:
+        port: The debugging port to expose.
+
+    Returns:
+        The created subprocess running Arc.
+    """
+    arc_path = Path("/Applications/Arc.app/Contents/MacOS/Arc")
+    if not arc_path.exists():
+        raise FileNotFoundError(f"Arc browser not found at {arc_path}")
+
+    return await asyncio.create_subprocess_exec(
+        str(arc_path),
+        f"--remote-debugging-port={port}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )

--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -12,7 +12,10 @@ class StagehandConfig(BaseModel):
     Configuration for the Stagehand client.
 
     Attributes:
-        env (str): Environment type. 'BROWSERBASE' for remote usage
+        env (str): Environment type. 'BROWSERBASE' for remote usage,
+            'LOCAL' for a standard local browser, 'ARC' to launch the Arc
+            browser in debug mode, or 'ARC_PERSIST' to attach to an existing
+            Arc browser session.
         api_key (Optional[str]): BrowserbaseAPI key for authentication.
         project_id (Optional[str]): Browserbase Project identifier.
         api_url (Optional[str]): Stagehand API URL.
@@ -35,7 +38,7 @@ class StagehandConfig(BaseModel):
         experimental (bool): Enable experimental features.
     """
 
-    env: Literal["BROWSERBASE", "LOCAL"] = "BROWSERBASE"
+    env: Literal["BROWSERBASE", "LOCAL", "ARC", "ARC_PERSIST"] = "BROWSERBASE"
     api_key: Optional[str] = Field(
         None, alias="apiKey", description="Browserbase API key for authentication"
     )

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -16,7 +16,7 @@ from playwright.async_api import (
 from playwright.async_api import Page as PlaywrightPage
 
 from .agent import Agent
-from .api import _create_session, _execute
+from .api import _attach_arc_session, _create_arc_session, _create_session, _execute
 from .browser import (
     cleanup_browser_resources,
     connect_browserbase_browser,
@@ -204,14 +204,17 @@ class Stagehand:
         self._local_user_data_dir_temp: Optional[Path] = (
             None  # To store path if created temporarily
         )
+        self._arc_process = None  # Handle to Arc browser process
 
         # Initialize metrics tracking
         self.metrics = StagehandMetrics()
         self._inference_start_time = 0  # To track inference time
 
         # Validate env
-        if self.env not in ["BROWSERBASE", "LOCAL"]:
-            raise ValueError("env must be either 'BROWSERBASE' or 'LOCAL'")
+        if self.env not in ["BROWSERBASE", "LOCAL", "ARC", "ARC_PERSIST"]:
+            raise ValueError(
+                "env must be 'BROWSERBASE', 'LOCAL', 'ARC', or 'ARC_PERSIST'"
+            )
 
         # Initialize the centralized logger with the specified verbosity
         self.on_log = self.config.logger or default_log_handler
@@ -262,7 +265,7 @@ class Stagehand:
         self.context: Optional[StagehandContext] = None
         self.use_api = self.config.use_api
         self.experimental = self.config.experimental
-        if self.experimental or self.env == "LOCAL":
+        if self.experimental or self.env in ["LOCAL", "ARC", "ARC_PERSIST"]:
             self.use_api = False
         if (
             self.browserbase_session_create_params
@@ -475,8 +478,10 @@ class Stagehand:
         """
         Public init() method.
         For BROWSERBASE: Creates or resumes the server session, starts Playwright, connects to remote browser.
-        For LOCAL: Starts Playwright, launches a local persistent context or connects via CDP.
-        Sets up self.page in both cases.
+        For LOCAL, ARC, and ARC_PERSIST: Starts Playwright, launches a local persistent
+        context or connects via CDP. ARC mode launches the Arc browser in debug mode,
+        while ARC_PERSIST attaches to an existing Arc session.
+        Sets up self.page in all cases.
         """
         if self._initialized:
             self.logger.debug("Stagehand is already initialized; skipping init()")
@@ -533,6 +538,49 @@ class Stagehand:
             except Exception:
                 await self.close()
                 raise
+
+        elif self.env == "ARC":
+            # Launch Arc in debug mode and connect via CDP
+            await self._create_arc_session()
+
+            try:
+                (
+                    self._browser,
+                    self._context,
+                    self.context,
+                    self._page,
+                    self._local_user_data_dir_temp,
+                ) = await connect_local_browser(
+                    self._playwright,
+                    self.local_browser_launch_options,
+                    self,
+                    self.logger,
+                )
+                self._playwright_page = self._page._page
+            except Exception:
+                await self.close()
+                raise
+        elif self.env == "ARC_PERSIST":
+            # Attach to an existing Arc debug session and connect via CDP
+            await self._attach_arc_session()
+
+            try:
+                (
+                    self._browser,
+                    self._context,
+                    self.context,
+                    self._page,
+                    self._local_user_data_dir_temp,
+                ) = await connect_local_browser(
+                    self._playwright,
+                    self.local_browser_launch_options,
+                    self,
+                    self.logger,
+                )
+                self._playwright_page = self._page._page
+            except Exception:
+                await self.close()
+                raise
         else:
             # Should not happen due to __init__ validation
             raise RuntimeError(f"Invalid env value: {self.env}")
@@ -563,7 +611,8 @@ class Stagehand:
         """
         Clean up resources.
         For BROWSERBASE: Ends the session on the server and stops Playwright.
-        For LOCAL: Closes the local context, stops Playwright, and removes temporary directories.
+        For LOCAL, ARC, and ARC_PERSIST: Closes the local context, stops Playwright, and removes
+        temporary directories. ARC mode also terminates the Arc browser process.
         """
         if self._closed:
             return
@@ -607,6 +656,17 @@ class Stagehand:
             self._local_user_data_dir_temp,
             self.logger,
         )
+
+        # Terminate Arc browser process if running
+        if self.env == "ARC" and self._arc_process:
+            try:
+                self.logger.debug("Terminating Arc browser process...")
+                self._arc_process.terminate()
+                await self._arc_process.wait()
+            except Exception:
+                pass
+            finally:
+                self._arc_process = None
 
         self._closed = True
 
@@ -727,7 +787,7 @@ class Stagehand:
         Returns:
             A LivePageProxy that delegates to the active StagehandPage or None if not initialized
         """
-        if not self._initialized:
+        if not self._initialized and not self._live_page_proxy:
             return None
 
         # Create the live page proxy if it doesn't exist
@@ -736,7 +796,14 @@ class Stagehand:
 
         return self._live_page_proxy
 
+    @page.setter
+    def page(self, value: Optional[StagehandPage]):
+        """Allow tests or advanced users to override the live page proxy."""
+        self._live_page_proxy = value
+
 
 # Bind the imported API methods to the Stagehand class
 Stagehand._create_session = _create_session
+Stagehand._create_arc_session = _create_arc_session
+Stagehand._attach_arc_session = _attach_arc_session
 Stagehand._execute = _execute

--- a/tests/unit/test_arc_support.py
+++ b/tests/unit/test_arc_support.py
@@ -1,0 +1,86 @@
+import asyncio
+import unittest.mock as mock
+
+import pytest
+
+from stagehand import Stagehand
+from stagehand.config import StagehandConfig
+
+
+@pytest.mark.asyncio
+async def test_create_arc_session_sets_session_and_cdp_url(monkeypatch):
+    config = StagehandConfig(env="ARC")
+    client = Stagehand(config=config)
+
+    mock_process = mock.Mock()
+
+    async def fake_launch_arc(port):
+        return mock_process
+
+    with mock.patch("stagehand.api.launch_arc_browser", fake_launch_arc), \
+         mock.patch("asyncio.sleep", new=mock.AsyncMock()):
+        await client._create_arc_session()
+
+    assert client.session_id is not None
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+    assert client._arc_process is mock_process
+
+
+@pytest.mark.asyncio
+async def test_init_calls_create_arc_session(monkeypatch):
+    config = StagehandConfig(env="ARC")
+    client = Stagehand(config=config)
+
+    mock_playwright = mock.Mock()
+    mock_playwright_instance = mock.AsyncMock()
+    mock_playwright_instance.start = mock.AsyncMock(return_value=mock_playwright)
+
+    mock_browser_tuple = (mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), None)
+
+    async def fake_create_arc_session():
+        client.local_browser_launch_options["cdp_url"] = "http://localhost:9222"
+
+    with mock.patch("stagehand.main.async_playwright", return_value=mock_playwright_instance), \
+         mock.patch("stagehand.main.connect_local_browser", new=mock.AsyncMock(return_value=mock_browser_tuple)), \
+         mock.patch.object(Stagehand, "_create_arc_session", new=mock.AsyncMock(side_effect=fake_create_arc_session)) as mock_arc:
+        await client.init()
+        mock_arc.assert_awaited_once()
+        assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+
+
+@pytest.mark.asyncio
+async def test_attach_arc_session_sets_session_and_cdp_url():
+    config = StagehandConfig(env="ARC_PERSIST")
+    client = Stagehand(config=config)
+
+    with mock.patch("stagehand.api.launch_arc_browser") as launch_mock:
+        await client._attach_arc_session()
+        launch_mock.assert_not_called()
+
+    assert client.session_id is not None
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+    assert client._arc_process is None
+
+
+@pytest.mark.asyncio
+async def test_init_calls_attach_arc_session(monkeypatch):
+    config = StagehandConfig(env="ARC_PERSIST")
+    client = Stagehand(config=config)
+
+    mock_playwright = mock.Mock()
+    mock_playwright_instance = mock.AsyncMock()
+    mock_playwright_instance.start = mock.AsyncMock(return_value=mock_playwright)
+
+    mock_browser_tuple = (mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), None)
+
+    async def fake_attach_arc_session():
+        client.local_browser_launch_options["cdp_url"] = "http://localhost:9222"
+
+    with mock.patch("stagehand.main.async_playwright", return_value=mock_playwright_instance), \
+         mock.patch("stagehand.main.connect_local_browser", new=mock.AsyncMock(return_value=mock_browser_tuple)), \
+         mock.patch.object(Stagehand, "_attach_arc_session", new=mock.AsyncMock(side_effect=fake_attach_arc_session)) as attach_mock, \
+         mock.patch.object(Stagehand, "_create_arc_session", new=mock.AsyncMock()) as create_mock:
+        await client.init()
+        attach_mock.assert_awaited_once()
+        create_mock.assert_not_called()
+        assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"


### PR DESCRIPTION
### **User description**
## Summary
- allow overriding the live page proxy for testing and always launch Arc when in ARC mode
- add `launch_arc_browser` wrapper for running Arc in remote-debug mode
- cover Arc session setup with new unit tests
- support persistent Arc sessions via `ARC_PERSIST` environment

## Testing
- `./format.sh`
- `pytest tests/unit/test_arc_support.py -q`
- `pytest tests/unit/test_client_initialization.py::TestClientInitialization::test_init_with_direct_params -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1a3b0e15c8324911806f3feb8a949


___

### **PR Type**
Enhancement


___

### **Description**
- Add Arc browser support with two new environment modes

- Enable launching Arc in debug mode or attaching to existing sessions

- Update configuration and examples to include Arc options

- Add comprehensive unit tests for Arc functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["StagehandConfig"] -- "ARC mode" --> Launch["launch_arc_browser()"]
  Config -- "ARC_PERSIST mode" --> Attach["_attach_arc_session()"]
  Launch --> CDP["CDP Connection"]
  Attach --> CDP
  CDP --> Browser["Arc Browser Session"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>arc.py</strong><dd><code>New Arc browser launcher utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-e981ee7734be41e4c2a9e79dd616278dbd0c8d02491b27d1d8fa34fca0f8090e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.py</strong><dd><code>Add Arc session creation and attachment methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-c97542feeac96bef5ec52cc509b18ce376eb5631f66d16aed55b1661d5e190e3">+65/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Integrate Arc browser support into client initialization</code>&nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-eecc7283a18349c273fcf7e2073b06c19fe8952208f0d8181f44d522ee348492">+75/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Add ARC and ARC_PERSIST environment options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-99670e70ca17faf4a91952e0d37351dcb749cf2728e0a9b48860fde12710fb9e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add Arc test marker configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pytest.ini</strong><dd><code>Add Arc test markers for pytest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_arc_support.py</strong><dd><code>Comprehensive unit tests for Arc functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-fa58fe2e321ff406ac36c6ee86e16501e0fab954efeb08812237668d0756fdeb">+86/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>agent_example.py</strong><dd><code>Update configuration comments with Arc options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-0a7c0d1b60ed3b946c4258c008586c1f5ff77d6f583bf0d90d7cfb20a9634c70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.py</strong><dd><code>Update configuration comments with Arc options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-9fb5aadb45b410c48744b000c6720e4361d8d32948f81b145cd4e3b9abd177d4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quickstart.py</strong><dd><code>Update configuration comments with Arc options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update configuration example with Arc options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

