### PR TITLE
feat: support arc browser sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class Companies(BaseModel):
 async def main():
     # Create configuration
     config = StagehandConfig(
-        env = "BROWSERBASE", # or LOCAL
+        env = "BROWSERBASE", # or LOCAL, ARC, or ARC_PERSIST
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="google/gemini-2.5-flash-preview-05-20",

--- a/examples/agent_example.py
+++ b/examples/agent_example.py
@@ -36,7 +36,7 @@ async def main():
     # Build a unified configuration object for Stagehand
     config = StagehandConfig(
         env="BROWSERBASE",
-        # env="LOCAL",
+        # env="LOCAL", "ARC", or "ARC_PERSIST",
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="gpt-4o",

--- a/examples/example.py
+++ b/examples/example.py
@@ -49,6 +49,7 @@ async def main():
     # Build a unified configuration object for Stagehand
     config = StagehandConfig(
         env="BROWSERBASE",
+        # env="LOCAL", "ARC", or "ARC_PERSIST",
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         headless=False,

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -20,7 +20,7 @@ class Companies(BaseModel):
 async def main():
     # Create configuration
     config = StagehandConfig(
-        env = "BROWSERBASE", # or LOCAL
+        env = "BROWSERBASE", # or LOCAL, ARC, or ARC_PERSIST
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="google/gemini-2.5-flash-preview-05-20",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ python_classes = [ "Test*",]
 python_functions = [ "test_*",]
 asyncio_mode = "auto"
 addopts = [ "--cov=stagehand", "--cov-report=html:htmlcov", "--cov-report=term-missing", "--cov-report=xml", "--strict-markers", "--strict-config", "-ra", "--tb=short",]
-markers = [ "unit: Unit tests for individual components", "integration: Integration tests requiring multiple components", "e2e: End-to-end tests with full workflows", "slow: Tests that take longer to run", "browserbase: Tests requiring Browserbase connection", "local: Tests for local browser functionality", "llm: Tests involving LLM interactions", "mock: Tests using mock objects only", "performance: Performance and load tests", "smoke: Quick smoke tests for basic functionality",]
+markers = [ "unit: Unit tests for individual components", "integration: Integration tests requiring multiple components", "e2e: End-to-end tests with full workflows", "slow: Tests that take longer to run", "browserbase: Tests requiring Browserbase connection", "local: Tests for local browser functionality", "arc: Tests for Arc browser functionality", "llm: Tests involving LLM interactions", "mock: Tests using mock objects only", "performance: Performance and load tests", "smoke: Quick smoke tests for basic functionality",]
 filterwarnings = [ "ignore::DeprecationWarning", "ignore::PendingDeprecationWarning", "ignore::UserWarning:pytest_asyncio", "ignore::RuntimeWarning",]
 minversion = "7.0"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ markers =
     integration: marks tests as integration tests
     smoke: marks tests as smoke tests
     local: marks tests as local integration tests
+    arc: marks tests as Arc browser integration tests
     api: marks tests as API integration tests
     e2e: marks tests as end-to-end tests
     regression: marks tests as regression tests

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,11 +1,15 @@
+import asyncio
 import json
+import uuid
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
+from urllib.parse import urlparse
 
+from .arc import launch_arc_browser
 from .utils import convert_dict_keys_to_camel_case
 
-__all__ = ["_create_session", "_execute"]
+__all__ = ["_create_session", "_create_arc_session", "_attach_arc_session", "_execute"]
 
 
 async def _create_session(self):
@@ -97,6 +101,120 @@ async def _create_session(self):
         raise RuntimeError(f"Invalid response format: {resp.text}")
 
     self.session_id = data["data"]["sessionId"]
+
+
+async def _create_arc_session(self):
+    """Launch Arc browser in remote debugging mode and set up a local session.
+
+    This method starts the Arc browser using its default macOS installation path
+    and enables the remote debugging protocol. A unique session ID is generated
+    for use throughout Stagehand just like in Browserbase mode, but no external
+    server is contacted. The launched browser can then be accessed via CDP using
+    the generated debugging port.
+    """
+
+    default_port = 9222
+    # Determine desired CDP URL / port from launch options if provided
+    cdp_url = None
+    if hasattr(self, "local_browser_launch_options"):
+        cdp_url = self.local_browser_launch_options.get("cdp_url")
+    if cdp_url:
+        parsed = urlparse(cdp_url)
+        debug_port = parsed.port or default_port
+    else:
+        debug_port = default_port
+        cdp_url = f"http://localhost:{debug_port}"
+
+    self.logger.info("Launching Arc browser in debug mode...")
+
+    arc_available = True
+    try:
+        # Start Arc with remote debugging enabled
+        self._arc_process = await launch_arc_browser(debug_port)
+
+        # Give the browser a moment to start listening on the port
+        await asyncio.sleep(2)
+    except FileNotFoundError:
+        self.logger.log(
+            "Arc browser not found; falling back to local Chromium.", level=1
+        )
+        self._arc_process = None
+        arc_available = False
+    except Exception as e:
+        self.logger.log(
+            f"Failed to launch Arc browser ({e}); falling back to local Chromium.",
+            level=1,
+        )
+        self._arc_process = None
+        arc_available = False
+
+    # Generate a session ID if one was not provided
+    if not self.session_id:
+        self.session_id = str(uuid.uuid4())
+
+    if arc_available:
+        # Ensure subsequent calls connect via CDP to the launched Arc browser
+        if hasattr(self, "local_browser_launch_options"):
+            self.local_browser_launch_options.setdefault("cdp_url", cdp_url)
+        else:
+            self.local_browser_launch_options = {"cdp_url": cdp_url}
+    else:
+        # Remove any CDP configuration so a standard Chromium session is launched
+        if hasattr(self, "local_browser_launch_options"):
+            self.local_browser_launch_options.pop("cdp_url", None)
+        else:
+            self.local_browser_launch_options = {}
+
+
+async def _attach_arc_session(self):
+    """Attach to an existing Arc browser debug session.
+
+    This helper configures Stagehand to connect to a pre-launched Arc browser
+    running with the remote debugging protocol enabled. Unlike
+    :func:`_create_arc_session`, this method does not start a new browser
+    process, allowing users to leverage already-authenticated Arc sessions.
+    """
+
+    default_port = 9222
+
+    # Determine CDP URL/port from launch options if provided
+    cdp_url = None
+    if hasattr(self, "local_browser_launch_options"):
+        cdp_url = self.local_browser_launch_options.get("cdp_url")
+    if cdp_url:
+        parsed = urlparse(cdp_url)
+        debug_port = parsed.port or default_port
+    else:
+        debug_port = default_port
+        cdp_url = f"http://localhost:{debug_port}"
+
+    # Generate a session ID if one was not provided
+    if not self.session_id:
+        self.session_id = str(uuid.uuid4())
+
+    # Check if an Arc debug session is reachable; otherwise fall back to Chromium
+    version_url = urlparse(cdp_url)._replace(path="/json/version").geturl()
+    try:
+        resp = await self._client.get(version_url, timeout=1.0)
+        arc_running = resp.status_code == 200
+    except Exception:
+        arc_running = False
+
+    if arc_running:
+        # Ensure we have a CDP URL pointing to the running Arc instance
+        if hasattr(self, "local_browser_launch_options"):
+            self.local_browser_launch_options.setdefault("cdp_url", cdp_url)
+        else:
+            self.local_browser_launch_options = {"cdp_url": cdp_url}
+    else:
+        self.logger.log(
+            "Arc debug session not reachable; falling back to local Chromium.",
+            level=1,
+        )
+        if hasattr(self, "local_browser_launch_options"):
+            self.local_browser_launch_options.pop("cdp_url", None)
+        else:
+            self.local_browser_launch_options = {}
 
 
 async def _execute(self, method: str, payload: dict[str, Any]) -> Any:

--- a/stagehand/arc.py
+++ b/stagehand/arc.py
@@ -1,0 +1,23 @@
+import asyncio
+from pathlib import Path
+
+
+async def launch_arc_browser(port: int = 9222) -> asyncio.subprocess.Process:
+    """Launch the Arc browser with remote debugging enabled.
+
+    Args:
+        port: The debugging port to expose.
+
+    Returns:
+        The created subprocess running Arc.
+    """
+    arc_path = Path("/Applications/Arc.app/Contents/MacOS/Arc")
+    if not arc_path.exists():
+        raise FileNotFoundError(f"Arc browser not found at {arc_path}")
+
+    return await asyncio.create_subprocess_exec(
+        str(arc_path),
+        f"--remote-debugging-port={port}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )

--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -12,7 +12,10 @@ class StagehandConfig(BaseModel):
     Configuration for the Stagehand client.
 
     Attributes:
-        env (str): Environment type. 'BROWSERBASE' for remote usage
+        env (str): Environment type. 'BROWSERBASE' for remote usage,
+            'LOCAL' for a standard local browser, 'ARC' to launch the Arc
+            browser in debug mode, or 'ARC_PERSIST' to attach to an existing
+            Arc debug session.
         api_key (Optional[str]): BrowserbaseAPI key for authentication.
         project_id (Optional[str]): Browserbase Project identifier.
         api_url (Optional[str]): Stagehand API URL.
@@ -35,7 +38,7 @@ class StagehandConfig(BaseModel):
         experimental (bool): Enable experimental features.
     """
 
-    env: Literal["BROWSERBASE", "LOCAL"] = "BROWSERBASE"
+    env: Literal["BROWSERBASE", "LOCAL", "ARC", "ARC_PERSIST"] = "BROWSERBASE"
     api_key: Optional[str] = Field(
         None, alias="apiKey", description="Browserbase API key for authentication"
     )

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -16,7 +16,7 @@ from playwright.async_api import (
 from playwright.async_api import Page as PlaywrightPage
 
 from .agent import Agent
-from .api import _create_session, _execute
+from .api import _attach_arc_session, _create_arc_session, _create_session, _execute
 from .browser import (
     cleanup_browser_resources,
     connect_browserbase_browser,
@@ -204,14 +204,17 @@ class Stagehand:
         self._local_user_data_dir_temp: Optional[Path] = (
             None  # To store path if created temporarily
         )
+        self._arc_process = None  # Handle to Arc browser process
 
         # Initialize metrics tracking
         self.metrics = StagehandMetrics()
         self._inference_start_time = 0  # To track inference time
 
         # Validate env
-        if self.env not in ["BROWSERBASE", "LOCAL"]:
-            raise ValueError("env must be either 'BROWSERBASE' or 'LOCAL'")
+        if self.env not in ["BROWSERBASE", "LOCAL", "ARC", "ARC_PERSIST"]:
+            raise ValueError(
+                "env must be 'BROWSERBASE', 'LOCAL', 'ARC', or 'ARC_PERSIST'"
+            )
 
         # Initialize the centralized logger with the specified verbosity
         self.on_log = self.config.logger or default_log_handler
@@ -262,7 +265,7 @@ class Stagehand:
         self.context: Optional[StagehandContext] = None
         self.use_api = self.config.use_api
         self.experimental = self.config.experimental
-        if self.experimental or self.env == "LOCAL":
+        if self.experimental or self.env in ["LOCAL", "ARC", "ARC_PERSIST"]:
             self.use_api = False
         if (
             self.browserbase_session_create_params
@@ -475,8 +478,10 @@ class Stagehand:
         """
         Public init() method.
         For BROWSERBASE: Creates or resumes the server session, starts Playwright, connects to remote browser.
-        For LOCAL: Starts Playwright, launches a local persistent context or connects via CDP.
-        Sets up self.page in both cases.
+        For LOCAL, ARC, and ARC_PERSIST: Starts Playwright, launches a local persistent context
+        or connects via CDP. ARC mode additionally launches the Arc browser in debug mode, while
+        ARC_PERSIST attaches to an existing Arc session.
+        Sets up self.page in all cases.
         """
         if self._initialized:
             self.logger.debug("Stagehand is already initialized; skipping init()")
@@ -533,6 +538,50 @@ class Stagehand:
             except Exception:
                 await self.close()
                 raise
+
+        elif self.env == "ARC":
+            # Launch Arc in debug mode and connect via CDP
+            await self._create_arc_session()
+
+            try:
+                (
+                    self._browser,
+                    self._context,
+                    self.context,
+                    self._page,
+                    self._local_user_data_dir_temp,
+                ) = await connect_local_browser(
+                    self._playwright,
+                    self.local_browser_launch_options,
+                    self,
+                    self.logger,
+                )
+                self._playwright_page = self._page._page
+            except Exception:
+                await self.close()
+                raise
+
+        elif self.env == "ARC_PERSIST":
+            # Attach to a running Arc instance via CDP
+            await self._attach_arc_session()
+
+            try:
+                (
+                    self._browser,
+                    self._context,
+                    self.context,
+                    self._page,
+                    self._local_user_data_dir_temp,
+                ) = await connect_local_browser(
+                    self._playwright,
+                    self.local_browser_launch_options,
+                    self,
+                    self.logger,
+                )
+                self._playwright_page = self._page._page
+            except Exception:
+                await self.close()
+                raise
         else:
             # Should not happen due to __init__ validation
             raise RuntimeError(f"Invalid env value: {self.env}")
@@ -563,7 +612,8 @@ class Stagehand:
         """
         Clean up resources.
         For BROWSERBASE: Ends the session on the server and stops Playwright.
-        For LOCAL: Closes the local context, stops Playwright, and removes temporary directories.
+        For LOCAL, ARC, and ARC_PERSIST: Closes the local context, stops Playwright,
+        and removes temporary directories. ARC mode also terminates the Arc browser process.
         """
         if self._closed:
             return
@@ -607,6 +657,17 @@ class Stagehand:
             self._local_user_data_dir_temp,
             self.logger,
         )
+
+        # Terminate Arc browser process if running
+        if self.env == "ARC" and self._arc_process:
+            try:
+                self.logger.debug("Terminating Arc browser process...")
+                self._arc_process.terminate()
+                await self._arc_process.wait()
+            except Exception:
+                pass
+            finally:
+                self._arc_process = None
 
         self._closed = True
 
@@ -727,7 +788,7 @@ class Stagehand:
         Returns:
             A LivePageProxy that delegates to the active StagehandPage or None if not initialized
         """
-        if not self._initialized:
+        if not self._initialized and not self._live_page_proxy:
             return None
 
         # Create the live page proxy if it doesn't exist
@@ -736,7 +797,14 @@ class Stagehand:
 
         return self._live_page_proxy
 
+    @page.setter
+    def page(self, value: Optional[StagehandPage]):
+        """Allow tests or advanced users to override the live page proxy."""
+        self._live_page_proxy = value
+
 
 # Bind the imported API methods to the Stagehand class
 Stagehand._create_session = _create_session
+Stagehand._create_arc_session = _create_arc_session
+Stagehand._attach_arc_session = _attach_arc_session
 Stagehand._execute = _execute

--- a/tests/unit/test_arc_support.py
+++ b/tests/unit/test_arc_support.py
@@ -1,0 +1,158 @@
+import asyncio
+import unittest.mock as mock
+
+import pytest
+
+from stagehand import Stagehand
+from stagehand.config import StagehandConfig
+import httpx
+
+
+@pytest.mark.asyncio
+async def test_create_arc_session_sets_session_and_cdp_url(monkeypatch):
+    config = StagehandConfig(env="ARC")
+    client = Stagehand(config=config)
+
+    mock_process = mock.Mock()
+
+    async def fake_launch_arc(port):
+        return mock_process
+
+    with mock.patch("stagehand.api.launch_arc_browser", fake_launch_arc), \
+         mock.patch("asyncio.sleep", new=mock.AsyncMock()):
+        await client._create_arc_session()
+
+    assert client.session_id is not None
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+    assert client._arc_process is mock_process
+
+
+@pytest.mark.asyncio
+async def test_create_arc_session_respects_custom_cdp_url(monkeypatch):
+    config = StagehandConfig(
+        env="ARC", local_browser_launch_options={"cdp_url": "http://localhost:9333"}
+    )
+    client = Stagehand(config=config)
+
+    mock_process = mock.Mock()
+    captured = {}
+
+    async def fake_launch_arc(port):
+        captured["port"] = port
+        return mock_process
+
+    with mock.patch("stagehand.api.launch_arc_browser", fake_launch_arc), \
+         mock.patch("asyncio.sleep", new=mock.AsyncMock()):
+        await client._create_arc_session()
+
+    assert captured["port"] == 9333
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9333"
+    assert client._arc_process is mock_process
+
+
+@pytest.mark.asyncio
+async def test_create_arc_session_falls_back_to_chromium(monkeypatch):
+    config = StagehandConfig(env="ARC")
+    client = Stagehand(config=config)
+
+    async def fake_launch_arc(port):
+        raise FileNotFoundError("Arc not installed")
+
+    with mock.patch("stagehand.api.launch_arc_browser", fake_launch_arc), \
+         mock.patch("asyncio.sleep", new=mock.AsyncMock()):
+        await client._create_arc_session()
+
+    assert client.session_id is not None
+    assert "cdp_url" not in client.local_browser_launch_options
+    assert client._arc_process is None
+
+
+@pytest.mark.asyncio
+async def test_init_calls_create_arc_session(monkeypatch):
+    config = StagehandConfig(env="ARC")
+    client = Stagehand(config=config)
+
+    mock_playwright = mock.Mock()
+    mock_playwright_instance = mock.AsyncMock()
+    mock_playwright_instance.start = mock.AsyncMock(return_value=mock_playwright)
+
+    mock_browser_tuple = (mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), None)
+
+    async def fake_create_arc_session():
+        client.local_browser_launch_options["cdp_url"] = "http://localhost:9222"
+
+    with mock.patch("stagehand.main.async_playwright", return_value=mock_playwright_instance), \
+         mock.patch("stagehand.main.connect_local_browser", new=mock.AsyncMock(return_value=mock_browser_tuple)), \
+         mock.patch.object(Stagehand, "_create_arc_session", new=mock.AsyncMock(side_effect=fake_create_arc_session)) as mock_arc:
+        await client.init()
+        mock_arc.assert_awaited_once()
+        assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+
+
+@pytest.mark.asyncio
+async def test_attach_arc_session_sets_session_and_cdp_url(monkeypatch):
+    config = StagehandConfig(env="ARC_PERSIST")
+    client = Stagehand(config=config)
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = 200
+    with mock.patch.object(client._client, "get", return_value=mock_resp), \
+         mock.patch("stagehand.api.launch_arc_browser") as launch_mock:
+        await client._attach_arc_session()
+        launch_mock.assert_not_called()
+
+    assert client.session_id is not None
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"
+
+
+@pytest.mark.asyncio
+async def test_attach_arc_session_falls_back_to_chromium(monkeypatch):
+    config = StagehandConfig(env="ARC_PERSIST")
+    client = Stagehand(config=config)
+
+    async def fake_get(url, *args, **kwargs):
+        raise httpx.ConnectError("no arc", request=None)
+
+    with mock.patch.object(client._client, "get", side_effect=fake_get):
+        await client._attach_arc_session()
+
+    assert client.session_id is not None
+    assert "cdp_url" not in client.local_browser_launch_options
+
+
+@pytest.mark.asyncio
+async def test_attach_arc_session_respects_custom_cdp_url(monkeypatch):
+    config = StagehandConfig(
+        env="ARC_PERSIST", local_browser_launch_options={"cdp_url": "http://localhost:9333"}
+    )
+    client = Stagehand(config=config)
+
+    mock_resp = mock.Mock()
+    mock_resp.status_code = 200
+    with mock.patch.object(client._client, "get", return_value=mock_resp):
+        await client._attach_arc_session()
+
+    assert client.session_id is not None
+    assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9333"
+
+
+@pytest.mark.asyncio
+async def test_init_calls_attach_arc_session(monkeypatch):
+    config = StagehandConfig(env="ARC_PERSIST")
+    client = Stagehand(config=config)
+
+    mock_playwright = mock.Mock()
+    mock_playwright_instance = mock.AsyncMock()
+    mock_playwright_instance.start = mock.AsyncMock(return_value=mock_playwright)
+
+    mock_browser_tuple = (mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), None)
+
+    async def fake_attach_arc_session():
+        client.local_browser_launch_options["cdp_url"] = "http://localhost:9222"
+
+    with mock.patch("stagehand.main.async_playwright", return_value=mock_playwright_instance), \
+         mock.patch("stagehand.main.connect_local_browser", new=mock.AsyncMock(return_value=mock_browser_tuple)), \
+         mock.patch.object(Stagehand, "_attach_arc_session", new=mock.AsyncMock(side_effect=fake_attach_arc_session)) as mock_attach:
+        await client.init()
+        mock_attach.assert_awaited_once()
+        assert client.local_browser_launch_options["cdp_url"] == "http://localhost:9222"


### PR DESCRIPTION
### **User description**
## Summary
- allow overriding the live page proxy for testing and always launch Arc when in ARC mode
- add `launch_arc_browser` wrapper for running Arc in remote-debug mode
- cover Arc session setup with new unit tests
- enable `ARC_PERSIST` mode to attach to an existing Arc debug session without spawning a new browser
- add Chromium fallback when Arc is unavailable, ensuring ARC and ARC_PERSIST still work
- respect custom `cdp_url` values when launching or attaching to Arc sessions, defaulting to `http://localhost:9222`

## Testing
- `./format.sh`
- `pytest tests/unit/test_arc_support.py -q`
- `pytest tests/unit/test_client_initialization.py::TestClientInitialization::test_init_with_direct_params -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1a3b0e15c8324911806f3feb8a949


___

### **PR Type**
Enhancement


___

### **Description**
- Add Arc browser support with ARC and ARC_PERSIST modes

- Enable custom CDP URL configuration for Arc sessions

- Implement Arc browser launch and attachment functionality

- Add comprehensive unit tests for Arc browser integration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["StagehandConfig"] -- "ARC/ARC_PERSIST modes" --> Session["Session Creation"]
  Session -- "launch_arc_browser()" --> Arc["Arc Browser Process"]
  Session -- "attach to existing" --> Existing["Existing Arc Session"]
  Arc -- "CDP connection" --> Browser["Browser Connection"]
  Existing -- "CDP connection" --> Browser
  Browser -- "fallback on failure" --> Chromium["Local Chromium"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Add ARC and ARC_PERSIST environment options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-99670e70ca17faf4a91952e0d37351dcb749cf2728e0a9b48860fde12710fb9e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add Arc test marker configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pytest.ini</strong><dd><code>Add Arc test marker definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>arc.py</strong><dd><code>Create Arc browser launcher utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-e981ee7734be41e4c2a9e79dd616278dbd0c8d02491b27d1d8fa34fca0f8090e">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>api.py</strong><dd><code>Add Arc session creation and attachment methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-c97542feeac96bef5ec52cc509b18ce376eb5631f66d16aed55b1661d5e190e3">+119/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Integrate Arc modes into client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-eecc7283a18349c273fcf7e2073b06c19fe8952208f0d8181f44d522ee348492">+76/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_arc_support.py</strong><dd><code>Add comprehensive Arc browser unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-fa58fe2e321ff406ac36c6ee86e16501e0fab954efeb08812237668d0756fdeb">+158/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>agent_example.py</strong><dd><code>Update configuration comments for Arc modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-0a7c0d1b60ed3b946c4258c008586c1f5ff77d6f583bf0d90d7cfb20a9634c70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>example.py</strong><dd><code>Update configuration comments for Arc modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-9fb5aadb45b410c48744b000c6720e4361d8d32948f81b145cd4e3b9abd177d4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quickstart.py</strong><dd><code>Update configuration comments for Arc modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-0874f112033c11d75839017d9f3948cc6ea2c8cd058ae2b82b174650929756a9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update configuration documentation for Arc modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/arthrod/stagehand-python/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

